### PR TITLE
Implemented one-up API and helper methods

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -126,6 +126,18 @@ app.get('/users/:userId/workout/generate-plan/:lengthMinutes&:targetMuscleGroup'
   }
 })
 
+app.get('/users/:userId/workout/one-up/:workoutPlanId', cors(), async function (req, res) {
+  try {
+    res.json(await workoutService.generateOneUpWorkoutPlan(
+        JSON.parse(req.params.userId), 
+        JSON.parse(req.params.workoutPlanId), 
+        dbConfig
+    ));
+  } catch(ex) {
+    res.status(constants.ERROR_RESPONSE).send(ex);
+  }
+})
+
 app.put('/users/:userId/workout/change-difficulty/:factor&:targetMuscleGroup', cors(), async function (req, res) {
   try {
     res.sendStatus(await workoutService.modifyWorkoutDifficulty(

--- a/server/src/data/workoutData.js
+++ b/server/src/data/workoutData.js
@@ -95,6 +95,28 @@ module.exports = {
       }
     },
 
+    getWorkoutExercisesByWorkoutPlanId: function(workoutPlanId, dbConfig) {
+      try {
+        return sql
+          .connect(dbConfig)
+          .then((pool) => {
+            return pool
+              .request()
+              .input("wpid", sql.Int, workoutPlanId)
+              .query(
+                "SELECT * FROM workout_exercise WHERE workout_plan_id = @wpid"
+              );
+          })
+          .then((result) => {
+            if (result.recordset.length == 0) throw ('No workout exercises found for given workout plan id: ' + workoutPlanId);
+            return result.recordset;
+          })
+      } catch(ex) {
+          console.log(ex);
+          throw ex;
+      }
+    },
+
     createWorkoutHistoryEntry: function(workoutPlan, lengthOfWorkoutSec, userId, dbConfig) {
       try {
           return sql

--- a/server/src/engine/workoutPlanGenerationEngine.js
+++ b/server/src/engine/workoutPlanGenerationEngine.js
@@ -7,8 +7,12 @@ const MIN_REST_SEC = 15;
 const WORKOUT_TO_REST_RATIO = 5;
 const TIME_ESTIMATE_SHIFT_FACTOR = 0.5;
 
+const ONE_UP_DIFFICULTY_INCREASE = 0.1;
+
 module.exports = {
-    generateWorkoutPlan: function(lengthMinutes, possibleExercises, multiplier, planId) {
+    // Generates a new workout plan with the given possible exercises to include, multiplier, 
+    // desired length in minutes, and the new plan id to associate with the generated plan
+    generateNewWorkoutPlan: function(lengthMinutes, possibleExercises, multiplier, planId) {
         var workoutPlan = {
             workout_plan_id: planId,
             exercises: [],
@@ -106,6 +110,30 @@ module.exports = {
         workoutPlan['spottr_points'] = calculateSpottrPoints(curLenSeconds, multiplier);
 
         return workoutPlan;
+    },
+
+
+    // Generates a new "one-up" workout plan from a passed workout plan and multiplier.
+    // Order of exercises does not change, only the number of reps.
+    //
+    // The multiplier determines how much harder to make the "one-up" workout. Larger 
+    // multiplier will lead to a more difficult workout being generated.
+    generateOneUpWorkoutPlan: function(oldWorkoutPlan, multiplier, newPlanId) {
+        var actualDifficultyIncrease = ONE_UP_DIFFICULTY_INCREASE * multiplier;
+        var newPlan = util.clone(oldWorkoutPlan);
+
+        for (var i = 0; i < newPlan.exercises.length; i++) {
+            newPlan.exercises[i].reps = Math.ceil(newPlan.exercises[i].reps * (1 + actualDifficultyIncrease));
+        }
+
+        newPlan.workout_plan_id = newPlanId;
+        newPlan.associated_multiplier = util.roundToThree(newPlan.associated_multiplier * (1 + actualDifficultyIncrease));
+        newPlan.spottr_points = calculateSpottrPoints(
+            newPlan.est_length_sec,
+            newPlan.associated_multiplier
+        );
+
+        return newPlan;
     }
 }
 

--- a/server/src/service/workoutService.js
+++ b/server/src/service/workoutService.js
@@ -10,6 +10,8 @@ const MIN_MULTIPLIER = 0.2;
 
 const PERCENT_DIFF_RECALC_TRIGGER = 1.15;
 
+const BREAK_ID = 20;
+
 module.exports = {
     // Generates a workout plan via the algorithm, perists it to the database, and returns it to the caller
     generateWorkoutPlan: async function (userId, lengthMinutes, targetMuscleGroup, dbConfig) {
@@ -19,7 +21,7 @@ module.exports = {
         const possibleExercises = await data.getExercisesByTargetMuscleGroups(targetMuscleGroup, dbConfig);
         const workoutPlanId = await data.createWorkoutPlanEntry(dbConfig);
 
-        var workoutPlan = generator.generateWorkoutPlan(
+        var workoutPlan = generator.generateNewWorkoutPlan(
             lengthMinutes, 
             possibleExercises, 
             userMultiplier, 
@@ -39,6 +41,48 @@ module.exports = {
         return workoutPlan;
     },
 
+
+    // Generates a workout plan which is slightly more difficult than another workout plan that
+    // is passed as a parameter. 
+    // 
+    // The exercises in the new plan are the same, all that is changed is the number of reps per set. 
+    // As well, the difficulty added to the workout is also dependent on the user's multiplier for 
+    // the given muscle group.
+    generateOneUpWorkoutPlan: async function (userId, workoutPlanId, dbConfig) {
+        // Collect data from given user and existing workout plan id and reassemble accordingly
+        const oldWorkoutPlan = await data.getWorkoutPlanById(workoutPlanId, dbConfig);
+        const exercisesInPlan = await data.getWorkoutExercisesByWorkoutPlanId(workoutPlanId, dbConfig);
+
+        const user = await userData.getUserByUserId(userId, dbConfig);
+        const userMultiplier = await data.getUserMultiplier(oldWorkoutPlan.major_muscle_group_id, user.user_multiplier_id, dbConfig);
+
+        const exerciseData = await data.getExercisesByTargetMuscleGroups(oldWorkoutPlan.major_muscle_group_id, dbConfig);
+        const reassembledWorkoutPlan = reassembleWorkoutPlan(oldWorkoutPlan, exercisesInPlan, exerciseData);
+
+        // Create new workout plan entry for the "one-up" plan
+        const newWorkoutPlanId = await data.createWorkoutPlanEntry(dbConfig);
+
+        // Create the new plan, and record the generated data in the database
+        var workoutPlan = generator.generateOneUpWorkoutPlan(
+            reassembledWorkoutPlan, 
+            userMultiplier, 
+            newWorkoutPlanId
+        );
+
+        data.updateWorkoutPlan(
+            workoutPlan['workout_plan_id'],
+            workoutPlan['est_length_sec'],
+            oldWorkoutPlan['major_muscle_group_id'],
+            workoutPlan['associated_multiplier'],
+            workoutPlan['spottr_points'],
+            dbConfig
+        );
+        data.createWorkoutExerciseEntries(workoutPlan, dbConfig);
+
+        return workoutPlan;
+    },
+
+
     // Changes a user's multiplier for a given muscle group by a given factor
     modifyWorkoutDifficulty: async function (userId, targetMuscleGroup, changeFactor, dbConfig) {
         // Collect current multiplier
@@ -54,6 +98,9 @@ module.exports = {
         return constants.SUCCESS_RESPONSE;
     },
 
+
+    // Records a workout as complete for a given user. As a result, the user's multiplier may be updated, a Firebase
+    // notification is sent to other users, and associated data is added to the database to record the workout as complete.
     completeWorkout: async function (userId, lengthOfWorkoutSec, workoutPlanId, dbConfig) {
         // Generate new entry in the workout history table for completed workout
         const workoutPlan = await data.getWorkoutPlanById(workoutPlanId, dbConfig);
@@ -109,4 +156,62 @@ function calculateNewMultiplier(percentageDifference, currentMultiplier) {
     }
     
     return util.roundToThree(currentMultiplier + changeValue);
+}
+
+
+// Using data that can be collected from the database tables, this function reconstructs a workout
+// plan and reproduces the same format which the FE expects from the generateNewWorkoutPlan API
+function reassembleWorkoutPlan(oldWorkoutPlan, oldWorkoutExercises, exerciseData) {
+    var reassembledPlan = {
+        workout_plan_id: oldWorkoutPlan.id,
+        exercises: [],
+        breaks: []
+    };
+    
+    // Combine the breaks and exercise lists (like the usual plan generation)
+    exerciseCount = 0;
+    breakCount = 0;
+
+    for (var i = 0; i < oldWorkoutExercises.length; i++) {
+        var currentExercise = oldWorkoutExercises[i];
+
+        if (currentExercise.exercise_id == BREAK_ID) { 
+            var reassembledBreak = {
+                name: "Rest",
+                exercise_id: BREAK_ID,
+                duration_sec: currentExercise.num_reps,
+                workout_order_num: currentExercise.workout_order_num
+            };
+
+            reassembledPlan.breaks[breakCount] = reassembledBreak;
+            breakCount++;
+        } else {
+            var relevantExercise = exerciseData.find(obj => { return obj.id === currentExercise.exercise_id });
+            if (typeof relevantExercise === 'undefined') throw 'Required exercise data is missing for plan reconstruction!';
+
+            var reassembledExercise = {
+                name: relevantExercise.name,
+                exercise_id: relevantExercise.id,
+                description: relevantExercise.description,
+                major_muscle_group_id: relevantExercise.major_muscle_group_id,
+                sets: currentExercise.num_sets,
+                reps: currentExercise.num_reps,
+                workout_order_num: currentExercise.workout_order_num
+            };
+
+            reassembledPlan.exercises[exerciseCount] = reassembledExercise;
+            exerciseCount++;
+        }
+    }
+
+    // Ensure data is in the correct order within the exercise and break lists
+    reassembledPlan.exercises.sort((a,b) => a.workout_order_num - b.workout_order_num);
+    reassembledPlan.breaks.sort((a,b) => a.workout_order_num - b.workout_order_num);
+
+    // Add final additional data
+    reassembledPlan.est_length_sec = oldWorkoutPlan.est_length_sec;
+    reassembledPlan.associated_multiplier = oldWorkoutPlan.associated_multiplier;
+    reassembledPlan.spottr_points = oldWorkoutPlan.spottr_points;
+
+    return reassembledPlan;
 }


### PR DESCRIPTION
Finished implementing the one-up feature in the BE. The data returned from the new GET endpoint is formatted the same as when a brand new plan is generated. In other words, there should be limited work to properly integrate with the FE as it is very similar to what we are already doing for normal plan generation / use.

Closes #23 